### PR TITLE
获取应用名称时，兼容多语言apk

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -61,7 +61,7 @@ type Permission struct {
 	Name string `xml:"name,attr"`
 }
 
-func NewAppParser(name string) (*AppInfo, error) {
+func New(name string) (*AppInfo, error) {
 	file, err := os.Open(name)
 	if err != nil {
 		return nil, err
@@ -197,7 +197,11 @@ func parseApkIconAndLabel(name string) (image.Image, string, error) {
 		Density: 720,
 	})
 
-	label, _ := pkg.label(nil)
+	// label, _ := pkg.label(&ResTableConfig{
+	// 	// Language: [2]uint8{'z', 'h'},
+	// 	// Country: [2]uint8{'C', 'N'},
+	// })
+	label, _ := pkg.label(&ResTableConfig{})
 
 	return icon, label, nil
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -8,13 +8,14 @@ import (
 	"testing"
 )
 
-func TestNewAppParser(t *testing.T) {
+func TestAppParser(t *testing.T) {
 	apkFile := "testdata/helloworld.apk"
-	app, err := NewAppParser(apkFile)
+	app, err := New(apkFile)
 	if err != nil {
 		t.Log(err)
 		return
 	}
+	fmt.Printf("Name: %v\n", app.Name)
 	fmt.Printf("BundleId: %v\n", app.BundleId)
 	fmt.Printf("Md5: %v\n", app.Md5)
 	fmt.Printf("Signature md5: %v\n", app.CertInfo.Md5)

--- a/table.go
+++ b/table.go
@@ -191,7 +191,7 @@ func IsResID(s string) bool {
 // ParseResID parses ResId.
 func ParseResID(s string) (ResID, error) {
 	if !IsResID(s) {
-		return 0, fmt.Errorf("androidbinary: %s is not ResID", s)
+		return 0, fmt.Errorf("apkparser: %s is not ResID", s)
 	}
 	id, err := strconv.ParseUint(s[3:], 16, 32)
 	if err != nil {
@@ -272,12 +272,12 @@ func (p *TablePackage) findEntry(typeIndex, entryIndex int, config *ResTableConf
 func (f *TableFile) GetResource(id ResID, config *ResTableConfig) (interface{}, error) {
 	p := f.findPackage(id.Package())
 	if p == nil {
-		return nil, fmt.Errorf("androidbinary: package 0x%02X not found", id.Package())
+		return nil, fmt.Errorf("apkparser: package 0x%02X not found", id.Package())
 	}
 	e := p.findEntry(id.Type(), id.Entry(), config)
 	v := e.Value
 	if v == nil {
-		return nil, fmt.Errorf("androidbinary: entry 0x%04X not found", id.Entry())
+		return nil, fmt.Errorf("apkparser: entry 0x%04X not found", id.Entry())
 	}
 	switch v.DataType {
 	case TypeNull:


### PR DESCRIPTION
1. 调整应用名称逻辑，支持多语言，取默认语言包的应用名称

原方式：
```
label, _ := pkg.label(nil)
```

当前： 
```
label, _ := pkg.label(&ResTableConfig{})
```

2. 简化方法名 `NewAppParser` -> `New` 